### PR TITLE
OTS-1056 Build script for accelerator-textchat-js broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Click [here](https://www.npmjs.com/search?q=opentok-acc-pack) for a list of all 
 
 ## Exploring the code
 
-The `TextChatAccPack` class in text-chat-acc-pack.js is the backbone of the text chat communication features for the app.
+The `TextChatAccPack` class in `opentok-text-chat.js` is the backbone of the text chat communication features for the app.
 
 This class sets up the text chat UI views and events, and provides functions for sending, receiving, and rendering individual chat messages.
 
@@ -126,4 +126,3 @@ otCore.on('messageSent', event =>  . . .)
 otCore.on('errorSendingMessage', error =>  . . .)
 ```
 ### Multiparty video communication sample app using the Accelerator TextChat with best-practices for Javascript (https://github.com/opentok/accelerator-sample-apps-js).
-

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-PUBLIC="../../sample-app/public"
-LOGGING="../../sample-app/node_modules/opentok-solutions-logging/opentok-solutions-logging.js"
-
 task="$1"
 
 #Run unit tests
@@ -24,8 +21,6 @@ if [ "$task" == "-d" ]; then
 		cp -v node_modules/opentok-solutions-logging/dist/opentok-solutions-logging.js src/opentok-solutions-logging.js
 		gulp dist
 		cd dist
-    cp -v text-chat-acc-pack.js $PUBLIC/js/components/text-chat-acc-pack.js
-    cp -v theme.css $PUBLIC/css/theme.css
     gulp zip
 		exit 0
 	else

--- a/build.sh
+++ b/build.sh
@@ -17,8 +17,6 @@ if [ "$task" == "-d" ]; then
 		cd opentok.js-text-chat
 		npm i
 		npm update
-  	cp -v node_modules/opentok-one-to-one-communication/opentok-one-to-one-communication.js src/opentok-one-to-one-communication.js
-		cp -v node_modules/opentok-solutions-logging/dist/opentok-solutions-logging.js src/opentok-solutions-logging.js
 		gulp dist
 		cd dist
     gulp zip

--- a/opentok.js-text-chat/gulpfile.js
+++ b/opentok.js-text-chat/gulpfile.js
@@ -8,15 +8,6 @@ var merge = require('merge-stream');
 
 
 gulp.task('js', function () {
-  var accPack = gulp.src([
-    'src/opentok-solutions-logging.js',
-    'src/opentok-one-to-one-communication.js',
-    'src/opentok-text-chat.js'
-  ])
-  .pipe(concat('text-chat-acc-pack.js'))
-  .pipe(uglify())
-  .pipe(gulp.dest('dist'));
-
   var npm = gulp.src('src/opentok-text-chat.js')
   .pipe(gulp.dest('dist'));
 
@@ -27,17 +18,7 @@ gulp.task('js', function () {
   }))
   .pipe(gulp.dest('dist'));
 
-  return merge(accPack, npm, min);
-});
-
-gulp.task('js-dev', function () {
-  return gulp.src([
-    'src/opentok-solutions-logging.js',
-    'src/opentok-one-to-one-communication.js',
-    'src/opentok-text-chat.js'
-  ])
-  .pipe(concat('text-chat-acc-pack.js'))
-  .pipe(gulp.dest('dist'));
+  return merge(npm, min);
 });
 
 
@@ -51,7 +32,7 @@ gulp.task('zip', function () {
   return gulp.src(
     [
       'dist/theme.css',
-      'dist/text-chat-acc-pack.js'
+      'dist/opentok-text-chat.js'
     ])
   .pipe(zip('opentok-js-text-chat-acc-pack-1.0.0.zip'))
   .pipe(gulp.dest('dist'));


### PR DESCRIPTION
## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I have resolved any merge conflicts. Confirmation: ____

## What's in this pull request?

This PR fixes the build script which had references to non-existent folders.

@adrice727 @marinaserranomontes 
Could you please check if the following paragraph makes sense to you? If not we can remove those commits:

I removed the gulp and build commands which created a file `text-chat-acc-pack.js`. This file combined the opentok-text-chat with logging and communications. This is inconsistent with the other accelerator libraries which also have logging in their dependencies. I also update the README to remove reference to this file.