### PR TITLE
[Issue-32] Move code to clear text input to sent message handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentok-text-chat",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "description": "OpenTok text chat accelerator pack",
   "main": "dist/opentok-text-chat.js",
   "directories": {

--- a/src/opentok-text-chat.js
+++ b/src/opentok-text-chat.js
@@ -178,18 +178,16 @@
 
     var chatholder = $(_newMessages);
     chatholder.append(view);
-    _cleanComposer();
     chatholder[0].scrollTop = chatholder[0].scrollHeight;
 
   };
 
   var _handleMessageSent = function (data) {
+    _cleanComposer();
     if (_shouldAppendMessage(data)) {
       $('.ots-item-text').last().append(['<span>', data.message, '</span>'].join(''));
       var chatholder = $(_newMessages);
       chatholder[0].scrollTop = chatholder[0].scrollHeight;
-      _cleanComposer();
-
     } else {
       _renderChatMessage(_sender.id, _sender.alias, data.message, data.sentOn);
     }


### PR DESCRIPTION
## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I have resolved any merge conflicts. Confirmation: ____

#### This fixes issue #32.

## What's in this pull request?
The `_cleanComposer()` method was being called in `_renderChatMessage` causing a user writing a message to lose their text when they received a message. This method only needs to be called for the sender, not the receivers. Rather than put a check as suggested it's better to simply move this code to _handleMessageSent. 

This was already the case for appending message, so I removed that command and put a new one before the `if` statement as it applies to both cases.